### PR TITLE
Adds dependent: :destroy for user_events

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -6,6 +6,6 @@ class Event < ApplicationRecord
                         :start_date,
                         :end_date
   
-  has_many :user_events
+  has_many :user_events, dependent: :destroy
   has_many :users, through: :user_events
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,6 @@ class User < ApplicationRecord
 
   validates_presence_of :name, :email, :image_url, :bio
 
-  has_many :user_events
+  has_many :user_events, dependent: :destroy
   has_many :events, through: :user_events
 end


### PR DESCRIPTION
#### User Story #41 Add dependent destroy
Closes #41 

#### What does this PR do?
- Adds `dependent: :destroy` to user_events in User and Event
- All tests passing
- Tested in localhost and looks good
- Paired PR with @mgoodhart5 

#### Any additional context you want to provide?
- Noticed this was necessary when we ran `rake db:seed` and it couldn't destroy records that had dependencies. This fixes that error. 