### PR TITLE
Create endpoint for PUT user_events #46

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,44 @@ Example:
 }
 ```
 
+#### `PUT /api/v1/users/:id/events/:event_id`
+Updates a user_event specified by the user ID and event ID. Updates the status of the event. 
+Returns a 200 status.
+Returns the event with the updated status of the associated user_event.
+This can be done as parameters or as a body.
+#### Parameters
+`status=wishlist`
+Options for the status are `wishlist`, `attending`, and `past`.
+
+Example:
+`PUT /api/v1/users/:id/events/:event_id?status=attending`
+#### Body
+Example:
+`{ "status": "attending" }`
+#### Returned Data Format
+```
+{
+    "data": {
+        "id": "20",
+        "type": "my_event",
+        "attributes": {
+            "name": "Crested Butte Bike Week",
+            "city": "Crested Butte",
+            "state": "CO",
+            "event_type": "biking",
+            "price": 0,
+            "start_date": "06-27-2019",
+            "end_date": "06-30-2019",
+            "description": "Bike week is a multi-day celebration of all things mountain bike in the Gunnison Valley. We still have the big thigh burner of a singletrack race, the Fat Tire 40, but now CB Bike Week is more of a celebration of how mountain biking defines our community in the summer. Join us for clinics, a film festival, the Chainless Downhill World Championships, good beer, and a great party.",
+            "event_url": "http://www.cbchamber.com/chamberevents/cb-bike-week/",
+            "image_url": "https://images.unsplash.com/photo-1544191696-102dbdaeeaa0?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2850&q=80",
+            "video_url": "https://www.youtube.com/embed/0cFSZCDMP_U",
+            "status": "attending"
+        }
+    }
+}
+```
+
 ## Installation
 
 ### Local Setup

--- a/app/controllers/api/v1/user_events_controller.rb
+++ b/app/controllers/api/v1/user_events_controller.rb
@@ -10,5 +10,17 @@ class Api::V1::UserEventsController < ApplicationController
     end
     render json: MyEventSerializer.new(Event.find(params[:event_id]), { params: { user_id: user.id } }), status: :created
   end
+  
+  def update
+    user_event = UserEvent.find_by(user_id: params[:id], event_id: params[:event_id])
+    user_event.update(user_event_params)
+    render json: MyEventSerializer.new(Event.find(params[:event_id]), { params: { user_id: params[:id] } })
+  end
+  
+  private
+  
+  def user_event_params
+    params.permit(:status)
+  end
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
       resources :events, only: [:index, :show]
       resources :users, only: [:show, :update]
       post 'users/:id/events/:event_id', to: 'user_events#create'
+      put 'users/:id/events/:event_id', to: 'user_events#update'
       namespace :users do
         get '/:id/events', to: 'events#index'
       end

--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -143,6 +143,6 @@ describe 'Users API' do
     expect(event[:id]).to eq(@event_1.id.to_s)
     expect(event[:attributes][:name]).to eq(@event_1.name)
     expect(event[:attributes][:status]).to eq('attending')
-    expect(@user_event_1.status).to eq('attending')
+    expect(@user_event_1.reload.status).to eq('attending')
   end
 end

--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -133,4 +133,16 @@ describe 'Users API' do
     expect(event[:attributes][:video_url]).to eq(@event_3.video_url)
     expect(event[:attributes][:status]).to eq('attending')
   end
+  it 'can update a user_event status' do
+    expect(@user_event_1.status).to eq('wishlist')
+    
+    put "/api/v1/users/#{@user.id}/events/#{@event_1.id}", params: { status: 'attending' }
+    
+    expect(response.status).to eq(200)
+    event = JSON.parse(response.body, symbolize_names: true)[:data]
+    expect(event[:id]).to eq(@event_1.id.to_s)
+    expect(event[:attributes][:name]).to eq(@event_1.name)
+    expect(event[:attributes][:status]).to eq('attending')
+    expect(@user_event_1.status).to eq('attending')
+  end
 end


### PR DESCRIPTION
#### User Story #46: Create endpoint for PUT /api/v1/users/:id/events/:event_id
Closes #46 
#### What does this PR do?
- Adds endpoint to be able to update the status for user_events
- Adds route and controller update action 
- Updates README
- All tests passing
- Tested manually with Postman and it is working

