### PR TITLE
Get events filtering#57

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,19 @@
 ### Events
 #### `GET /api/v1/events`
 Returns all the events in the system.
-#### Optional Parameters
-None at the moment. TBD depending on how we decide with the Front End to handle filtering.
+#### Optional Parameters for Filtering
+One or multiple of the following parameters can be added to endpoint to filter which events are returned.
+
+If no parameters are specified, all events are returned.
+
+`event_type`
+
+`state`
+
+`month`
+
+Example:
+`GET /api/v1/events?event_type=running&month=6`
 #### Returned Data Format
 ```
 {

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -2,6 +2,8 @@ class Api::V1::EventsController < ApplicationController
   def index
     if params[:event_type]
       render json: EventSerializer.new(Event.where(event_type: params[:event_type]))
+    elsif params[:state]
+      render json: EventSerializer.new(Event.where(state: params[:state]))
     else
       render json: EventSerializer.new(Event.all)
     end

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -4,6 +4,9 @@ class Api::V1::EventsController < ApplicationController
       render json: EventSerializer.new(Event.where(event_type: params[:event_type]))
     elsif params[:state]
       render json: EventSerializer.new(Event.where(state: params[:state]))
+    elsif params[:month]
+      month = params[:month].rjust(2, '0')
+      render json: EventSerializer.new(Event.where("start_date LIKE '#{month}%'"))
     else
       render json: EventSerializer.new(Event.all)
     end

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -1,18 +1,20 @@
 class Api::V1::EventsController < ApplicationController
   def index
-    if params[:event_type]
-      render json: EventSerializer.new(Event.where(event_type: params[:event_type]))
-    elsif params[:state]
-      render json: EventSerializer.new(Event.where(state: params[:state]))
-    elsif params[:month]
+    events = Event.where(filter_params)
+    if params[:month]
       month = params[:month].rjust(2, '0')
-      render json: EventSerializer.new(Event.where("start_date LIKE '#{month}%'"))
-    else
-      render json: EventSerializer.new(Event.all)
+      events = events.where("start_date LIKE '#{month}%'")
     end
+    render json: EventSerializer.new(events)
   end
   
   def show
     render json: EventSerializer.new(Event.find(params[:id]))
+  end
+  
+  private
+  
+  def filter_params
+    params.permit(:event_type, :state)
   end
 end

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -1,6 +1,10 @@
 class Api::V1::EventsController < ApplicationController
   def index
-    render json: EventSerializer.new(Event.all)
+    if params[:event_type]
+      render json: EventSerializer.new(Event.where(event_type: params[:event_type]))
+    else
+      render json: EventSerializer.new(Event.all)
+    end
   end
   
   def show

--- a/spec/requests/api/v1/events_request_spec.rb
+++ b/spec/requests/api/v1/events_request_spec.rb
@@ -44,4 +44,17 @@ describe 'Events API' do
     expect(results[:attributes][:image_url]).to eq(@event_2.image_url)
     expect(results[:attributes][:video_url]).to eq(@event_2.video_url)
   end
+  it 'returns events filtered by event_type' do
+    event_3 = Event.create(name: "Running 3", city: "Fruita", state: "CO", event_type: "running", price: 120, start_date: "04-13-2019", end_date: "04-14-2019", description: "A weekend of fun and running on the beautiful trails near Fruita, Colorado. The weekend includes a Trail Marathon & 50K races along with an Awards Party on Saturday, and 10K & Half Marathon races on Sunday.", event_url: "https://geminiadventures.com/trail-running-festival/", image_url: "https://geminiadventures.com/trail-running-festival/", video_url: "https://www.youtube.com/embed/UxVKnb8DMYQ")
+    event_type = 'running'
+    get "/api/v1/events?event_type=#{event_type}"
+    
+    expect(response.status).to eq(200)
+    events = JSON.parse(response.body, symbolize_names: true)[:data]
+    expect(events.count).to eq(2)
+    expect(events[0][:id]).to eq(@event_1.id.to_s)
+    expect(events[0][:name]).to eq(@event_1.name)
+    expect(events[1][:id]).to eq(event_3.id.to_s)
+    expect(events[1][:name]).to eq(event_3.name)
+  end
 end

--- a/spec/requests/api/v1/events_request_spec.rb
+++ b/spec/requests/api/v1/events_request_spec.rb
@@ -57,7 +57,7 @@ describe 'Events API' do
     expect(events[1][:id]).to eq(event_3.id.to_s)
     expect(events[1][:attributes][:name]).to eq(event_3.name)
   end
-  it 'returns events filtered by state' do
+  it 'returns events filtered by abbreviated state' do
     event_3 = Event.create(name: "Running 3", city: "Fruita", state: "CA", event_type: "running", price: 120, start_date: "04-13-2019", end_date: "04-14-2019", description: "A weekend of fun and running on the beautiful trails near Fruita, Colorado. The weekend includes a Trail Marathon & 50K races along with an Awards Party on Saturday, and 10K & Half Marathon races on Sunday.", event_url: "https://geminiadventures.com/trail-running-festival/", image_url: "https://geminiadventures.com/trail-running-festival/", video_url: "https://www.youtube.com/embed/UxVKnb8DMYQ")
     state = 'CO'
     get "/api/v1/events?state=#{state}"
@@ -69,5 +69,18 @@ describe 'Events API' do
     expect(events[0][:attributes][:name]).to eq(@event_1.name)
     expect(events[1][:id]).to eq(@event_2.id.to_s)
     expect(events[1][:attributes][:name]).to eq(@event_2.name)
+  end
+  it 'returns events filtered by month' do
+    event_3 = Event.create(name: "Running 3", city: "Fruita", state: "CA", event_type: "running", price: 120, start_date: "04-13-2019", end_date: "04-14-2019", description: "A weekend of fun and running on the beautiful trails near Fruita, Colorado. The weekend includes a Trail Marathon & 50K races along with an Awards Party on Saturday, and 10K & Half Marathon races on Sunday.", event_url: "https://geminiadventures.com/trail-running-festival/", image_url: "https://geminiadventures.com/trail-running-festival/", video_url: "https://www.youtube.com/embed/UxVKnb8DMYQ")
+    month = 4
+    get "/api/v1/events?month=#{month}"
+    
+    expect(response.status).to eq(200)
+    events = JSON.parse(response.body, symbolize_names: true)[:data]
+    expect(events.count).to eq(2)
+    expect(events[0][:id]).to eq(@event_1.id.to_s)
+    expect(events[0][:attributes][:name]).to eq(@event_1.name)
+    expect(events[1][:id]).to eq(event_3.id.to_s)
+    expect(events[1][:attributes][:name]).to eq(event_3.name)
   end
 end

--- a/spec/requests/api/v1/events_request_spec.rb
+++ b/spec/requests/api/v1/events_request_spec.rb
@@ -53,8 +53,8 @@ describe 'Events API' do
     events = JSON.parse(response.body, symbolize_names: true)[:data]
     expect(events.count).to eq(2)
     expect(events[0][:id]).to eq(@event_1.id.to_s)
-    expect(events[0][:name]).to eq(@event_1.name)
+    expect(events[0][:attributes][:name]).to eq(@event_1.name)
     expect(events[1][:id]).to eq(event_3.id.to_s)
-    expect(events[1][:name]).to eq(event_3.name)
+    expect(events[1][:attributes][:name]).to eq(event_3.name)
   end
 end

--- a/spec/requests/api/v1/events_request_spec.rb
+++ b/spec/requests/api/v1/events_request_spec.rb
@@ -83,4 +83,20 @@ describe 'Events API' do
     expect(events[1][:id]).to eq(event_3.id.to_s)
     expect(events[1][:attributes][:name]).to eq(event_3.name)
   end
+  it 'returns events filtered by a combination of state, month, and event_type' do
+    event_3 = Event.create(name: "Running 3", city: "Fruita", state: "CA", event_type: "running", price: 120, start_date: "04-13-2019", end_date: "04-14-2019", description: "A weekend of fun and running on the beautiful trails near Fruita, Colorado. The weekend includes a Trail Marathon & 50K races along with an Awards Party on Saturday, and 10K & Half Marathon races on Sunday.", event_url: "https://geminiadventures.com/trail-running-festival/", image_url: "https://geminiadventures.com/trail-running-festival/", video_url: "https://www.youtube.com/embed/UxVKnb8DMYQ")
+    event_4 = Event.create(name: "Running 4", city: "Fruita", state: "CO", event_type: "running", price: 120, start_date: "04-13-2019", end_date: "04-14-2019", description: "A weekend of fun and running on the beautiful trails near Fruita, Colorado. The weekend includes a Trail Marathon & 50K races along with an Awards Party on Saturday, and 10K & Half Marathon races on Sunday.", event_url: "https://geminiadventures.com/trail-running-festival/", image_url: "https://geminiadventures.com/trail-running-festival/", video_url: "https://www.youtube.com/embed/UxVKnb8DMYQ")
+    month = 4
+    event_type = 'running'
+    state = 'CO'
+    get "/api/v1/events?month=#{month}&event_type=#{event_type}&state=#{state}"
+    
+    expect(response.status).to eq(200)
+    events = JSON.parse(response.body, symbolize_names: true)[:data]
+    expect(events.count).to eq(2)
+    expect(events[0][:id]).to eq(@event_1.id.to_s)
+    expect(events[0][:attributes][:name]).to eq(@event_1.name)
+    expect(events[1][:id]).to eq(event_4.id.to_s)
+    expect(events[1][:attributes][:name]).to eq(event_4.name)
+  end
 end

--- a/spec/requests/api/v1/events_request_spec.rb
+++ b/spec/requests/api/v1/events_request_spec.rb
@@ -57,4 +57,17 @@ describe 'Events API' do
     expect(events[1][:id]).to eq(event_3.id.to_s)
     expect(events[1][:attributes][:name]).to eq(event_3.name)
   end
+  it 'returns events filtered by state' do
+    event_3 = Event.create(name: "Running 3", city: "Fruita", state: "CA", event_type: "running", price: 120, start_date: "04-13-2019", end_date: "04-14-2019", description: "A weekend of fun and running on the beautiful trails near Fruita, Colorado. The weekend includes a Trail Marathon & 50K races along with an Awards Party on Saturday, and 10K & Half Marathon races on Sunday.", event_url: "https://geminiadventures.com/trail-running-festival/", image_url: "https://geminiadventures.com/trail-running-festival/", video_url: "https://www.youtube.com/embed/UxVKnb8DMYQ")
+    state = 'CO'
+    get "/api/v1/events?state=#{state}"
+    
+    expect(response.status).to eq(200)
+    events = JSON.parse(response.body, symbolize_names: true)[:data]
+    expect(events.count).to eq(2)
+    expect(events[0][:id]).to eq(@event_1.id.to_s)
+    expect(events[0][:attributes][:name]).to eq(@event_1.name)
+    expect(events[1][:id]).to eq(@event_2.id.to_s)
+    expect(events[1][:attributes][:name]).to eq(@event_2.name)
+  end
 end


### PR DESCRIPTION
#### User Story #57: Add optional parameters to GET /api/v1/events 
Closes #57 
#### What does this PR do?
- Adds optional parameters in order to filter which events are returned in GET request
- Parameters are `state`, `event_type`, `month`
- For `state` - this is the two-letter state abbreviation
- For `month` - this is a numeric representation of the month of the start date (e.g. 1 for January through 12 for December)
- For `event_type` - single word describing the kind of event, e.g. `climbing`. 
- Can filter on one or multiple of the above parameters
- All tests passing
- Works locally testing in Postman
- Updates Readme
- Paired PR @mgoodhart5 

#### Any additional context you want to provide?
- Per discussion with whole team, the GET events endpoint returns ALL (or all filtered) results - past and future. This will NOT limit to future events. E.g. a filtered request with a month of `4` will return any events with a start_date in April, regardless of the year. 
